### PR TITLE
Redraw when the emojiSize changes.

### DIFF
--- a/Sources/EmojiText/Emoji/RenderedEmoji.swift
+++ b/Sources/EmojiText/Emoji/RenderedEmoji.swift
@@ -29,7 +29,10 @@ struct RenderedEmoji: Hashable, Equatable, Identifiable {
         self.baselineOffset = emoji.baselineOffset ?? baselineOffset
         self.symbolRenderingMode = nil
         self.placeholderId = nil
-        self.sourceHash = emoji.hashValue
+        var hasher = Hasher()
+        hasher.combine(emoji)
+        hasher.combine(targetHeight)
+        self.sourceHash = hasher.finalize()
     }
     
     init(from emoji: LocalEmoji, animated: Bool = false, targetHeight: CGFloat, baselineOffset: CGFloat? = nil) {
@@ -39,7 +42,10 @@ struct RenderedEmoji: Hashable, Equatable, Identifiable {
         self.baselineOffset = emoji.baselineOffset ?? baselineOffset
         self.symbolRenderingMode = nil
         self.placeholderId = nil
-        self.sourceHash = emoji.hashValue
+        var hasher = Hasher()
+        hasher.combine(emoji)
+        hasher.combine(targetHeight)
+        self.sourceHash = hasher.finalize()
     }
     
     init(from emoji: SFSymbolEmoji) {
@@ -58,7 +64,10 @@ struct RenderedEmoji: Hashable, Equatable, Identifiable {
         self.baselineOffset = emoji.baselineOffset
         self.symbolRenderingMode = emoji.symbolRenderingMode
         self.placeholderId = UUID()
-        self.sourceHash = emoji.hashValue
+        var hasher = Hasher()
+        hasher.combine(emoji)
+        hasher.combine(targetHeight)
+        self.sourceHash = hasher.finalize()
         
         switch placeholder {
         case let localEmoji as LocalEmoji:

--- a/Sources/EmojiText/EmojiText.swift
+++ b/Sources/EmojiText/EmojiText.swift
@@ -251,6 +251,7 @@ public struct EmojiText: View {
             hasher.combine(emoji)
         }
         hasher.combine(shouldAnimateIfNeeded)
+        hasher.combine(emojiSize)
         return hasher.finalize()
     }
     
@@ -323,6 +324,18 @@ public struct EmojiText: View {
 
 // swiftlint:disable force_unwrapping
 struct EmojiText_Previews: PreviewProvider {
+
+    struct EmojiTextWithSlider: View {
+        @State private var emojiSize: CGFloat = 20
+
+        var body: some View {
+            EmojiText(verbatim: "Hello World :mastodon: with a remote emoji",
+                      emojis: emojis)
+            .emojiSize(emojiSize)
+            Slider(value: $emojiSize, in: 1...50)
+        }
+    }
+
     static var emojis: [any CustomEmoji] {
         [
             RemoteEmoji(shortcode: "mastodon", url: URL(string: "https://files.mastodon.social/custom_emojis/images/000/003/675/original/089aaae26a2abcc1.png")!),
@@ -409,6 +422,14 @@ struct EmojiText_Previews: PreviewProvider {
                 .animated()
             } header: {
                 Text("Animated emoji")
+            }
+        }
+
+        List {
+            Section {
+                EmojiTextWithSlider()
+            } header: {
+                Text("EmojiSize")
             }
         }
     }


### PR DESCRIPTION
I noticed that the emoji are not redrawn when the environment's emojiSize changes. 

I thought it would be appropriate for them to be redrawn the same way when the environment's font changes.


## before

https://github.com/divadretlaw/EmojiText/assets/537587/f87f3541-c5e5-4c9d-aeae-a564f97f5f59

## after

https://github.com/divadretlaw/EmojiText/assets/537587/5caf2422-e9eb-4f1e-b9d3-57b85a6c0121



