### PR TITLE
Fixed a bug that prevented custom emoji from being redrawn

### DIFF
--- a/Sources/EmojiText/EmojiText.swift
+++ b/Sources/EmojiText/EmojiText.swift
@@ -69,7 +69,7 @@ public struct EmojiText: View {
                 }
                 
                 // Load actual emojis if needed (e.g. placeholders were set or source emojis changed)
-                if renderedHash != renderedEmojis.hashValue {
+                if renderedHash != renderedEmojis.hashValue || renderedEmojis.values.contains(where: { $0.isPlaceholder }){
                     renderedEmojis.merge(await loadEmojis()) { _, new in
                         new
                     }


### PR DESCRIPTION
I have found a bug that sometimes "loadEmojis()" is not called when a redraw occurs while displaying a placeholder anymore, so the placeholder remains.

I am attaching a video as it can be easily reproduced by changing the emojiSize fast with "animated()" enabled.

## example code


```swift
import SwiftUI
import EmojiText

struct ContentView: View {
    @State private var size: CGFloat = 20
    var body: some View {
        VStack {
            Slider(value: $size, in: 10...100, step: 0.05)
            Spacer()
            EmojiText(
                markdown: "PNG :emoji: AAA :large:",
                emojis: [
                    RemoteEmoji(
                        shortcode: "emoji",
                        url: .init(string: "https://files.mastodon.social/custom_emojis/images/000/003/675/original/089aaae26a2abcc1.png")!
                    ),
                    RemoteEmoji(
                        shortcode: "large",
                        url: .init(string: "https://s3.fedibird.com/custom_emojis/images/000/358/023/static/5fe65ba070089507.png")!
                    )
                ]
            )
            .animated()
            .emojiSize(size)
            .font(.system(size: size))
        }
        .padding()
    }
}

#Preview {
    ContentView()
}
```


## Before

The placeholder has continued to remain.

https://github.com/divadretlaw/EmojiText/assets/537587/21fe618a-873e-422c-be2e-15b43037fcac

## Fixed

https://github.com/divadretlaw/EmojiText/assets/537587/4ba54118-123e-4cd0-b1e8-2c90ec70a3c4


