### PR TITLE
Allow creating EmojiText from AttributedString

### DIFF
--- a/Sources/EmojiText/EmojiText.swift
+++ b/Sources/EmojiText/EmojiText.swift
@@ -131,7 +131,7 @@ import OSLog
     ///
     /// > Info:
     /// > Consider removing spaces between emojis as this will often drastically reduce
-    /// the amount of text contactenations needed to render the emojis.
+    /// the amount of text concatenations needed to render the emojis.
     /// >
     /// > There is a limit in SwiftUI Text concatenations and if this limit is reached the application will crash.
     public init(
@@ -153,7 +153,7 @@ import OSLog
     ///
     /// > Info:
     /// > Consider removing spaces between emojis as this will often drastically reduce
-    /// the amount of text contactenations needed to render the emojis.
+    /// the amount of text concatenations needed to render the emojis.
     /// >
     /// > There is a limit in SwiftUI Text concatenations and if this limit is reached the application will crash.
     public init(
@@ -174,7 +174,7 @@ import OSLog
     ///
     /// > Info:
     /// > Consider removing spaces between emojis as this will often drastically reduce
-    /// the amount of text contactenations needed to render the emojis.
+    /// the amount of text concatenations needed to render the emojis.
     /// >
     /// > There is a limit in SwiftUI Text concatenations and if this limit is reached the application will crash.
     public init<S>(
@@ -190,11 +190,19 @@ import OSLog
     /// - Parameters:
     ///     - content: The `AttributedString` to display.
     ///     - emojis: The custom emojis to render.
+    ///     - shouldOmitSpacesBetweenEmojis: Whether to omit spaces between emojis. Defaults to `true.
+    ///
+    /// > Info:
+    /// > Consider removing spaces between emojis as this will often drastically reduce
+    /// the amount of text concatenations needed to render the emojis.
+    /// >
+    /// > There is a limit in SwiftUI Text concatenations and if this limit is reached the application will crash.
     public init(
         _ content: AttributedString,
-        emojis: [any CustomEmoji]
+        emojis: [any CustomEmoji],
+        shouldOmitSpacesBetweenEmojis: Bool = true
     ) {
-        self.renderer = AttributedStringEmojiRenderer(attributedString: content)
+        self.renderer = AttributedStringEmojiRenderer(attributedString: content, shouldOmitSpacesBetweenEmojis: shouldOmitSpacesBetweenEmojis)
         self.emojis = emojis
     }
 

--- a/Sources/EmojiText/EmojiText.swift
+++ b/Sources/EmojiText/EmojiText.swift
@@ -243,7 +243,7 @@ import OSLog
     // swiftlint:disable:next legacy_hashing
     var hashValue: Int {
         var hasher = Hasher()
-        hasher.combine(renderer.hashValue)
+        hasher.combine(renderer)
         for emoji in emojis {
             hasher.combine(emoji)
         }

--- a/Sources/EmojiText/EmojiTextPresenter.swift
+++ b/Sources/EmojiText/EmojiTextPresenter.swift
@@ -93,19 +93,20 @@ extension EmojiTextPresenter {
     /// Helper to create `NSAttributedString` from emojis
     func makeString(from emojis: [String: LoadedEmoji]) -> NSAttributedString? {
         guard let raw else { return nil }
-        let renderer: EmojiRenderer = if let interpretedSyntax {
+        let renderer: any EmojiRenderer = if let interpretedSyntax {
             MarkdownEmojiRenderer(
+                string: raw,
                 font: emojiFont,
                 shouldOmitSpacesBetweenEmojis: shouldOmitSpacesBetweenEmojis,
                 interpretedSyntax: interpretedSyntax
             )
         } else {
             VerbatimEmojiRenderer(
+                string: raw,
                 shouldOmitSpacesBetweenEmojis: shouldOmitSpacesBetweenEmojis
             )
         }
         return renderer.render(
-            string: raw,
             emojis: emojis,
             size: emojiTargetHeight
         )

--- a/Sources/EmojiText/Render/AttributedStringEmojiRenderer.swift
+++ b/Sources/EmojiText/Render/AttributedStringEmojiRenderer.swift
@@ -33,7 +33,7 @@ struct AttributedStringEmojiRenderer: EmojiRenderer {
                 // with their shortcodes joined. Therefore we simply divide distance of the range by
                 // the character count of the emojo to calculate how often the emoji needs to be displayed
                 let distance = attributedString.distance(from: run.range.lowerBound, to: run.range.upperBound)
-                let count = emoji.shortcode.count + 2
+                let count = emoji.shortcode.count + 2 // leading and trailing ':'
 
                 if distance == count {
                     // Emoji is only displayed once
@@ -81,17 +81,7 @@ struct AttributedStringEmojiRenderer: EmojiRenderer {
     // MARK: - UIKit & AppKit
 
     func render(emojis: [String : LoadedEmoji], size: CGFloat?) -> NSAttributedString {
-        return NSAttributedString(attributedString)
-    }
-
-    // MARK: - Hashable & Equatable
-
-    static func ==(lhs: Self, rhs: Self) -> Bool {
-        lhs.attributedString == rhs.attributedString
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(attributedString)
+        NSAttributedString(renderAttributedString(with: emojis))
     }
 }
 

--- a/Sources/EmojiText/Render/AttributedStringEmojiRenderer.swift
+++ b/Sources/EmojiText/Render/AttributedStringEmojiRenderer.swift
@@ -1,0 +1,159 @@
+//
+//  AttributedStringEmojiRenderer.swift
+//  EmojiText
+//
+//  Created by Łukasz Rutkowski on 19/09/2025.
+//
+
+import Foundation
+import SwiftUI
+
+struct AttributedStringEmojiRenderer: EmojiRenderer {
+    let attributedString: AttributedString
+
+    // MARK: SwiftUI
+
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> Text {
+        renderAnimated(emojis: emojis, size: size, at: 0)
+    }
+
+    func renderAnimated(emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text {
+        let attributedString = renderAttributedString(with: emojis)
+
+        var result = Text(verbatim: "")
+        var partialString = AttributedPartialstring()
+
+        for run in attributedString.runs {
+            if let emoji = run.attributes[EmojiAttribute.self] {
+                // If the run is an emoji we render it as an interpolated image in a Text view
+                let text = Text(emoji, size: size, at: time)
+
+                // If the same emoji is added multiple times in a row the run gets merged into one
+                // with their shortcodes joined. Therefore we simply divide distance of the range by
+                // the character count of the emojo to calculate how often the emoji needs to be displayed
+                let distance = attributedString.distance(from: run.range.lowerBound, to: run.range.upperBound)
+                let count = emoji.shortcode.count + 2
+
+                if distance == count {
+                    // Emoji is only displayed once
+                    result = [
+                        result,
+                        Text(&partialString),
+                        text
+                    ]
+                        .compactMap { $0 }
+                        .joined()
+                } else {
+                    // Emojis is displayed multiple times
+                    result = [
+                        result,
+                        Text(&partialString),
+                        Text(repating: text, count: distance / count)
+                    ]
+                        .compactMap { $0 }
+                        .joined()
+                }
+            } else {
+                // Otherwise we just append the run to AttributedPartialstring
+                partialString.append(attributedString[run.range])
+            }
+        }
+
+        return [result, Text(&partialString)]
+            .compactMap { $0 }
+            .joined()
+    }
+
+    private func renderAttributedString(with emojis: [String: LoadedEmoji]) -> AttributedString {
+        var string = attributedString
+        for (shortcode, emoji) in emojis {
+            for range in attributedString.ranges(of: ":\(shortcode):") {
+                string[range].emoji = emoji
+            }
+        }
+        return string
+    }
+
+    // MARK: - UIKit & AppKit
+
+    func render(emojis: [String : LoadedEmoji], size: CGFloat?) -> NSAttributedString {
+        return NSAttributedString(attributedString)
+    }
+
+    // MARK: - Hashable & Equatable
+
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.attributedString == rhs.attributedString
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(attributedString)
+    }
+}
+
+// MARK: - Attributes
+
+private extension AttributeScopes {
+    struct EmojiAttributes: AttributeScope {
+        let emoji: EmojiAttribute
+    }
+
+    var emoji: EmojiAttributes.Type { EmojiAttributes.self }
+}
+
+private enum EmojiAttribute: AttributedStringKey {
+    typealias Value = LoadedEmoji
+    static let name = "Emoji"
+}
+
+private extension AttributeDynamicLookup {
+    subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.EmojiAttributes, T>) -> T {
+        self[T.self]
+    }
+}
+
+private extension AttributedString {
+    func ranges(of string: String) -> [Range<Index>] {
+        let plainText = String(characters)
+        var ranges: [Range<Index>] = []
+        var searchRange = plainText.startIndex..<plainText.endIndex
+        while let range = plainText.range(of: string, range: searchRange) {
+            if
+                let startIndex = Index(range.lowerBound, within: self),
+                let endIndex = Index(range.upperBound, within: self) {
+                ranges.append(startIndex..<endIndex)
+            }
+
+            searchRange = range.upperBound..<searchRange.upperBound
+        }
+        return ranges
+    }
+}
+
+#if DEBUG
+#Preview {
+    let hello = AttributedString("Hello", attributes: AttributeContainer().font(.body.bold()))
+    return List {
+        EmojiText(
+            hello + AttributedString(" :a:"),
+            emojis: .emojis
+        )
+        EmojiText(
+            hello + AttributedString(" World :wide:"),
+            emojis: .emojis
+        )
+        EmojiText(
+            hello + AttributedString(" World :test:"),
+            emojis: .emojis
+        )
+        EmojiText(
+            hello + AttributedString(" World :a: :wide: :a: :wide:"),
+            emojis: .emojis
+        )
+        EmojiText(
+            hello + AttributedString(" World :a::a::a:"),
+            emojis: .emojis
+        )
+    }
+}
+#endif

--- a/Sources/EmojiText/Render/EmojiRenderer.swift
+++ b/Sources/EmojiText/Render/EmojiRenderer.swift
@@ -8,16 +8,16 @@
 import SwiftUI
 import Combine
 
-protocol EmojiRenderer {
+protocol EmojiRenderer: Hashable {
     // SwiftUI
-    func render(string: String, emojis: [String: LoadedEmoji], size: CGFloat?) -> Text
-    func renderAnimated(string: String, emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> Text
+    func renderAnimated(emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text
     // AttributedString
-    func render(string: String, emojis: [String: LoadedEmoji], size: CGFloat?) -> NSAttributedString
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> NSAttributedString
 }
 
 extension EmojiRenderer {
-    func renderAnimated(string: String, emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text {
-        render(string: string, emojis: emojis, size: size)
+    func renderAnimated(emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text {
+        render(emojis: emojis, size: size)
     }
 }

--- a/Sources/EmojiText/Render/Markdown/MarkdownEmojiRenderer.swift
+++ b/Sources/EmojiText/Render/Markdown/MarkdownEmojiRenderer.swift
@@ -130,12 +130,23 @@ struct MarkdownEmojiRenderer: EmojiRenderer {
 
     // MARK: - Hashable & Equatable
 
-    static func ==(lhs: Self, rhs: Self) -> Bool {
-        lhs.string == rhs.string
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        guard
+            lhs.string == rhs.string,
+            lhs.font == rhs.font,
+            lhs.shouldOmitSpacesBetweenEmojis == rhs.shouldOmitSpacesBetweenEmojis,
+            lhs.interpretedSyntax == rhs.interpretedSyntax
+        else {
+            return false
+        }
+        return true
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(string)
+        hasher.combine(font)
+        hasher.combine(shouldOmitSpacesBetweenEmojis)
+        hasher.combine(interpretedSyntax)
     }
 }
 

--- a/Sources/EmojiText/Render/Markdown/MarkdownEmojiRenderer.swift
+++ b/Sources/EmojiText/Render/Markdown/MarkdownEmojiRenderer.swift
@@ -10,20 +10,23 @@ import Markdown
 import OSLog
 
 struct MarkdownEmojiRenderer: EmojiRenderer {
+    let string: String
     let font: EmojiFont?
     let shouldOmitSpacesBetweenEmojis: Bool
     let interpretedSyntax: AttributedString.MarkdownParsingOptions.InterpretedSyntax
     private let formatterOptions: MarkupFormatter.Options
-    
+
     init(
+        string: String,
         font: EmojiFont? = nil,
         shouldOmitSpacesBetweenEmojis: Bool,
         interpretedSyntax: AttributedString.MarkdownParsingOptions.InterpretedSyntax
     ) {
+        self.string = string
         self.font = font
         self.shouldOmitSpacesBetweenEmojis = shouldOmitSpacesBetweenEmojis
         self.interpretedSyntax = interpretedSyntax
-        
+
         self.formatterOptions = MarkupFormatter.Options(
             unorderedListMarker: .star,
             orderedListNumerals: .incrementing(start: 1)
@@ -46,11 +49,11 @@ struct MarkdownEmojiRenderer: EmojiRenderer {
 
     // MARK: - SwiftUI
 
-    func render(string: String, emojis: [String: LoadedEmoji], size: CGFloat?) -> SwiftUI.Text {
-        renderAnimated(string: string, emojis: emojis, size: size, at: 0)
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> SwiftUI.Text {
+        renderAnimated(emojis: emojis, size: size, at: 0)
     }
 
-    func renderAnimated(string: String, emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> SwiftUI.Text {
+    func renderAnimated(emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> SwiftUI.Text {
         let attributedString = renderAttributedString(from: string, with: emojis)
         
         var result = Text(verbatim: "")
@@ -115,7 +118,7 @@ struct MarkdownEmojiRenderer: EmojiRenderer {
 
     // MARK: - UIKit & AppKit
 
-    func render(string: String, emojis: [String: LoadedEmoji], size: CGFloat?) -> NSAttributedString {
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> NSAttributedString {
         let markdown = formatMarkdown(string, emojis: emojis)
         var renderer = MarkdownEmojiVisitor(
             emojis: emojis,
@@ -123,6 +126,16 @@ struct MarkdownEmojiRenderer: EmojiRenderer {
             interpretedSyntax: interpretedSyntax
         )
         return renderer.parseAndVisit(markdown)
+    }
+
+    // MARK: - Hashable & Equatable
+
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.string == rhs.string
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(string)
     }
 }
 

--- a/Sources/EmojiText/Render/VerbatimEmojiRenderer.swift
+++ b/Sources/EmojiText/Render/VerbatimEmojiRenderer.swift
@@ -71,16 +71,6 @@ struct VerbatimEmojiRenderer: EmojiRenderer {
         
         return text
     }
-
-    // MARK: - Hashable & Equatable
-
-    static func ==(lhs: Self, rhs: Self) -> Bool {
-        lhs.string == rhs.string
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(string)
-    }
 }
 
 #if DEBUG

--- a/Sources/EmojiText/Render/VerbatimEmojiRenderer.swift
+++ b/Sources/EmojiText/Render/VerbatimEmojiRenderer.swift
@@ -9,15 +9,16 @@ import SwiftUI
 import OSLog
 
 struct VerbatimEmojiRenderer: EmojiRenderer {
+    let string: String
     let shouldOmitSpacesBetweenEmojis: Bool
 
     // MARK: - SwiftUI
 
-    func render(string: String, emojis: [String: LoadedEmoji], size: CGFloat?) -> Text {
-        renderAnimated(string: string, emojis: emojis, size: size, at: 0)
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> Text {
+        renderAnimated(emojis: emojis, size: size, at: 0)
     }
 
-    func renderAnimated(string: String, emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text {
+    func renderAnimated(emojis: [String: LoadedEmoji], size: CGFloat?, at time: CFTimeInterval) -> Text {
         let string = renderString(from: string, with: emojis)
         
         var result = Text(verbatim: "")
@@ -39,7 +40,7 @@ struct VerbatimEmojiRenderer: EmojiRenderer {
 
     // MARK: - UIKit & AppKit
 
-    func render(string: String, emojis: [String: LoadedEmoji], size: CGFloat?) -> NSAttributedString {
+    func render(emojis: [String: LoadedEmoji], size: CGFloat?) -> NSAttributedString {
         let string = renderString(from: string, with: emojis)
 
         let result = NSMutableAttributedString()
@@ -69,6 +70,16 @@ struct VerbatimEmojiRenderer: EmojiRenderer {
         }
         
         return text
+    }
+
+    // MARK: - Hashable & Equatable
+
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.string == rhs.string
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(string)
     }
 }
 


### PR DESCRIPTION
I have an use case where I have already processed `AttributedString` and would like to display emojis contained in it. The emojis are present as `:shortcode:` text in the attributed string.

This pull request is an idea of how this could be implemented. The change is mainly in the renderers. The raw text was moved from the EmojiText to the renderers so different types can be used (`String`/`AttributedString`).
For now I mostly copied the implementation from `MarkdownEmojiRenderer` and adjusted it slightly to work with the provided `AttributedString`. Ideally this should be refactored to avoid duplication.

---

Is something like this viable, should I clean up and finish the implementation? Or perhaps there are better approaches.